### PR TITLE
Addition to description of five-guess algorithm

### DIFF
--- a/cswk1.tex
+++ b/cswk1.tex
@@ -128,6 +128,7 @@ Donald Knuth described an algorithm for Mastermind which, for every code with fo
         \end{enumerate}
     \end{enumerate}
     Choose the code which is guaranteed to eliminate the most options from $S$. This is calculated in the above step by calculating the minimum of eliminations for each code across all the possible scores it might get.
+    In the case of multiple codes producing the same number of guaranteed eliminations, a code which is still a member of $S$ should be picked over one which is not.
     \item Go to Step 3.
 \end{enumerate}
 


### PR DESCRIPTION
The description of the five-guess algorithm does not currently state that in the case of multiple codes producing the same guaranteed number of eliminations, one still in the set S should be chosen. This is a requirement of the algorithm as stated by Knuth in his paper (http://www.cs.uni.edu/~wallingf/teaching/cs3530/resources/knuth-mastermind.pdf) - 'If this minimum can be achieved by a "valid" pattern, a valid one should be used'.

Implementing the algorithm as currently stated (not necessarily choosing from codes left in S when there are multiple options) leads to an *almost* working solution which passes the unit tests in most cases, however fails to guess within 5 moves for a small number of codes ("eaea", "eaca", "eaaa" are examples of these).